### PR TITLE
Fixed Issues with backupKeySets and getActiveKey.

### DIFF
--- a/PolicyAndKeys-Client/Program.cs
+++ b/PolicyAndKeys-Client/Program.cs
@@ -92,7 +92,7 @@ namespace AADB2C.PolicyAndKeys.Client
 
                             if (!testRequests.CheckAndGenerateTest(ref args[0], ref cont))
                             {
-                                cont = System.IO.File.ReadAllText(args[0]);
+                                cont = System.IO.File.ReadAllText(args[0].Replace("\"", ""));
                                 request = userMode.HttpPost(cont);
                                 ExecuteResponse(request);
                             }
@@ -105,7 +105,7 @@ namespace AADB2C.PolicyAndKeys.Client
 
                             if (!testRequests.CheckAndGenerateTest(ref args[0], ref cont))
                             {
-                                cont = System.IO.File.ReadAllText(args[1]);
+                                cont = System.IO.File.ReadAllText(args[1].Replace("\"", ""));
                             }
                             request = userMode.HttpPutID(args[0], cont);
                             ExecuteResponse(request);
@@ -138,7 +138,8 @@ namespace AADB2C.PolicyAndKeys.Client
                             cont = args.Length == 1 ? string.Empty : args[1];
                             if (!testRequests.CheckAndGenerateTest(ref args[0], ref cont))
                             {
-                                cont = File.ReadAllText(args[1]);
+                                testRequests.GenerateKeySetID(ref args[0]);
+                                cont = File.ReadAllText(args[1].Replace("\"", ""));
                             }
                             request = userMode.HttpPostByCommandType(cmdType, args[0], cont);
                             ExecuteResponse(request);
@@ -203,7 +204,7 @@ namespace AADB2C.PolicyAndKeys.Client
             }
 
 
-            var parsArray = pars.Split(' ');
+            var parsArray = Regex.Split(pars, "\\s(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)");
             parameters = new List<string>(parsArray);
             if ((cmdType == CommandType.UPDATE && parameters.Count != 2) || parameters.Any(string.Empty.Contains))
             {
@@ -310,7 +311,15 @@ namespace AADB2C.PolicyAndKeys.Client
 
             Console.WriteLine(response.Headers);
             string taskContentString = response.Content.ReadAsStringAsync().Result;
-            Console.WriteLine(taskContentString);
+            try
+            {
+                Console.WriteLine(JValue.Parse(taskContentString).ToString(Formatting.Indented));
+            }
+            catch
+            {
+                Console.WriteLine(taskContentString);
+            }
+            
             return taskContentString;
         }
 

--- a/PolicyAndKeys-Lib/TestRequests.cs
+++ b/PolicyAndKeys-Lib/TestRequests.cs
@@ -153,5 +153,33 @@ namespace AADB2C.PolicyAndKeys.Lib
 
         }
 
+        public void GenerateKeySetID(ref string id)
+        {
+            var json = Constants.CreateKeyset;
+
+            json = json.Replace(Constants.KEYSETID_TOKEN, id);
+            var req = usrMode.HttpPost(json);
+            var content = ExecuteResponse(req);
+            var result = JToken.Parse(content);
+
+            var keySetId = (string)result.SelectToken("id");
+
+            if (keySetId is null)
+            {
+                var errorCode = (string)result.SelectToken("error.code");
+                if (errorCode == "AADB2C95028")
+                {
+                    // KeySet is already exists. Manually returning key by appending B2C_1A_
+                    keySetId = "B2C_1A_" + id;
+
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"Key Set with KeyID {keySetId} already exists and Graph API use existing key set id to add keys.");
+                    Console.ForegroundColor = ConsoleColor.White;
+                }
+            }
+
+            id = keySetId;
+        }
+
     }
 }

--- a/PolicyAndKeys-Lib/UserMode.cs
+++ b/PolicyAndKeys-Lib/UserMode.cs
@@ -17,7 +17,7 @@ namespace AADB2C.PolicyAndKeys.Lib
     public enum CommandType
 
     {
-        EXIT = 0, LIST = 1 , GET = 2, CREATE = 3, UPDATE = 4, DELETE =5, GENERATEKEY = 6, UPLOADSECRET = 7, UPLOADCERTIFICATE = 8, UPLOADPKCS = 9, GETACTIVEKEY = 10, BACKUPKEYSETS = 11 
+        EXIT = 0, LIST = 1 , GET = 2, CREATE = 3, UPDATE = 4, DELETE =5, GENERATEKEY = 6, UPLOADSECRET = 7, UPLOADCERTIFICATE = 8, UPLOADPKCS = 9, GETACTIVEKEY = 10, BACKUPKEYSETS = 11
     }
     public class UserMode
     {
@@ -40,12 +40,12 @@ namespace AADB2C.PolicyAndKeys.Lib
         public static string TFKeysetGenerateKey = "https://graph.microsoft.com/beta/trustFramework/keySets/{0}/generateKey";
 
         //GET https://graph.microsoft.com/beta/trustFramework/backupKeySets 
-        public static string TFKeysetBackups = "https://graph.microsoft.com/beta/trustFramework/backupKeySets";
+        public static string TFKeysetBackups = "https://graph.microsoft.com/beta/trustFramework/keySets/{0}/backupKeySets";
 
         //GET https://graph.microsoft.com/beta/trustFramework/keySets/{id}/getActiveKey 
-        public static string TFKeysetActiveKey = "https://graph.microsoft.com/beta/trustFramework/getActiveKey";
+        public static string TFKeysetActiveKey = "https://graph.microsoft.com/beta/trustFramework/keySets/{0}/getActiveKey";
 
-        
+
         public string TokenForUser { get; private set; }
 
         public UserMode(string token)
@@ -73,7 +73,7 @@ namespace AADB2C.PolicyAndKeys.Lib
         public HttpRequestMessage HttpGetByCommandType(CommandType cmdType, string id)
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, TFUri);
-            
+
             switch (cmdType)
             {
                 case CommandType.GETACTIVEKEY:
@@ -84,7 +84,7 @@ namespace AADB2C.PolicyAndKeys.Lib
 
                     break;
             }
-            
+
             AddHeaders(request);
             return request;
         }
@@ -124,18 +124,18 @@ namespace AADB2C.PolicyAndKeys.Lib
                     break;
                 case CommandType.UPLOADSECRET:
                     uri = string.Format(TFKeysetsUploadSecret, id);
-                    
+
                     break;
                 case CommandType.UPLOADPKCS:
                     uri = string.Format(TFKeysetsUploadPkcs12, id);
                     break;
                 case CommandType.UPLOADCERTIFICATE:
                     uri = string.Format(TFKeysetsUploadCertificate, id);
-                    
+
                     break;
             }
 
-            
+
             return HttpPost(uri, content);
         }
         public HttpRequestMessage HttpPost(string uri, string content)
@@ -155,7 +155,7 @@ namespace AADB2C.PolicyAndKeys.Lib
             return request;
         }
 
-         void AddHeaders(HttpRequestMessage requestMessage)
+        void AddHeaders(HttpRequestMessage requestMessage)
         {
             if (TokenForUser == null)
             {


### PR DESCRIPTION
## Purpose
To fix the issues in the sample to make it work for graph API requests
* generateKey
* backupKeySets
* getActiveKey

Added GenerateKeySetID method to generate an initial empty key to get the KeySet KeyID.
- Now console supports full file path including spaces along with multiple parameters
  - Example for GenerateKey:
       - TestingIEF "D:\B2C\KeySets\Sample RSA.json"